### PR TITLE
DA/GitHub oauth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@
 # Ignore simplecov reports
 /coverage.data
 /coverage/
+
+# Ignore application configuration
+/config/application.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+
+language: ruby
+services:
+  - postgresql
+script:
+  - bundle exec rake db:{create,migrate}
+  - bundle exec rspec

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'coffee-rails', '~> 4.2'
 gem 'jbuilder', '~> 2.5'
 gem 'bootsnap', '>= 1.1.0', require: false
 gem 'omniauth-github', github: 'omniauth/omniauth-github', branch: 'master'
+gem 'figaro'
 
 
 group :development, :test do

--- a/Gemfile
+++ b/Gemfile
@@ -3,39 +3,18 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby '2.5.1'
 gem 'bcrypt'
-# Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.2.4', '>= 5.2.4.2'
-# Use postgresql as the database for Active Record
 gem 'pg', '>= 0.18', '< 2.0'
-# Use Puma as the app server
 gem 'puma', '~> 3.11'
-# Use SCSS for stylesheets
 gem 'sass-rails', '~> 5.0'
-# Use Uglifier as compressor for JavaScript assets
 gem 'uglifier', '>= 1.3.0'
-# See https://github.com/rails/execjs#readme for more supported runtimes
-# gem 'mini_racer', platforms: :ruby
-
-# Use CoffeeScript for .coffee assets and views
 gem 'coffee-rails', '~> 4.2'
-# Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.5'
-# Use Redis adapter to run Action Cable in production
-# gem 'redis', '~> 4.0'
-# Use ActiveModel has_secure_password
-# gem 'bcrypt', '~> 3.1.7'
-
-# Use ActiveStorage variant
-# gem 'mini_magick', '~> 4.8'
-
-# Use Capistrano for deployment
-# gem 'capistrano-rails', group: :development
-
-# Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.1.0', require: false
+gem 'omniauth-github', github: 'omniauth/omniauth-github', branch: 'master'
+
 
 group :development, :test do
-  # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   gem 'pry'
   gem 'capybara'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,12 @@
+GIT
+  remote: https://github.com/omniauth/omniauth-github.git
+  revision: d001ed274276bf50e1e756bf38bce75509aa25ec
+  branch: master
+  specs:
+    omniauth-github (1.4.0)
+      omniauth (~> 1.5)
+      omniauth-oauth2 (>= 1.4.0, < 2.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -73,13 +82,19 @@ GEM
     docile (1.3.2)
     erubi (1.9.0)
     execjs (2.7.0)
+    faraday (1.0.1)
+      multipart-post (>= 1.2, < 3)
     ffi (1.12.2)
+    figaro (1.1.1)
+      thor (~> 0.14)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    hashie (4.1.0)
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
     jbuilder (2.10.0)
       activesupport (>= 5.0.0)
+    jwt (2.2.1)
     launchy (2.5.0)
       addressable (~> 2.7)
     listen (3.1.5)
@@ -99,9 +114,24 @@ GEM
     mini_portile2 (2.4.0)
     minitest (5.14.0)
     msgpack (1.3.3)
+    multi_json (1.14.1)
+    multi_xml (0.6.0)
+    multipart-post (2.1.1)
     nio4r (2.5.2)
     nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
+    oauth2 (1.4.4)
+      faraday (>= 0.8, < 2.0)
+      jwt (>= 1.0, < 3.0)
+      multi_json (~> 1.3)
+      multi_xml (~> 0.5)
+      rack (>= 1.2, < 3)
+    omniauth (1.9.1)
+      hashie (>= 3.4.6)
+      rack (>= 1.6.2, < 3)
+    omniauth-oauth2 (1.6.0)
+      oauth2 (~> 1.1)
+      omniauth (~> 1.9)
     pg (1.2.3)
     pry (0.13.0)
       coderay (~> 1.1)
@@ -148,14 +178,14 @@ GEM
     rspec-mocks (3.9.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
-    rspec-rails (3.9.1)
-      actionpack (>= 3.0)
-      activesupport (>= 3.0)
-      railties (>= 3.0)
-      rspec-core (~> 3.9.0)
-      rspec-expectations (~> 3.9.0)
-      rspec-mocks (~> 3.9.0)
-      rspec-support (~> 3.9.0)
+    rspec-rails (4.0.0)
+      actionpack (>= 4.2)
+      activesupport (>= 4.2)
+      railties (>= 4.2)
+      rspec-core (~> 3.9)
+      rspec-expectations (~> 3.9)
+      rspec-mocks (~> 3.9)
+      rspec-support (~> 3.9)
     rspec-support (3.9.2)
     ruby_dep (1.5.0)
     sass (3.7.4)
@@ -182,7 +212,7 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    thor (1.0.1)
+    thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.10)
     tzinfo (1.2.7)
@@ -209,9 +239,11 @@ DEPENDENCIES
   byebug
   capybara
   coffee-rails (~> 4.2)
+  figaro
   jbuilder (~> 2.5)
   launchy
   listen (>= 3.0.5, < 3.2)
+  omniauth-github!
   pg (>= 0.18, < 2.0)
   pry
   puma (~> 3.11)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,9 @@
 class ApplicationController < ActionController::Base
+  protect_from_forgery with: :exception
+
+  helper_method :current_user
+
+  def current_user
+    @current_user ||= User.find(session[:user_id]) if session[:user_id]
+  end
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,0 +1,4 @@
+class HomeController < ApplicationController
+  def index
+  end
+end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,0 +1,15 @@
+class SessionsController < ApplicationController
+  def create
+    user_info = request.env['omniauth.auth']
+    uid = user_info[:uid]
+    name = user_info[:info][:nickname]
+
+    user = User.find_by(uid: [uid])
+    if user.nil?
+      user = User.create(uid: uid, name: name, group_id: Group.first.id)
+    end
+    session[:user_id] = user.id
+
+    redirect_to '/'
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,11 +1,11 @@
 class User < ApplicationRecord
   validates_presence_of :name
-  validates_presence_of :email
   validates_presence_of :role
-
-  has_secure_password
+  validates :uid, uniqueness: true, presence: true
 
   has_many :posts
 
   belongs_to :group
+
+  enum role: { admin: 0, registered_user: 1 }
 end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,0 +1,2 @@
+<p><%= "Logged in as #{current_user.name}" if current_user %></p>
+<p>Welcome!</p>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,7 +11,7 @@
 
   <body>
     <nav class='topnav'>
-      <%= link_to 'Login with GitHub', github_login_path unless current_user %>
+      <%= link_to 'Log in with GitHub', github_login_path unless current_user %>
     </nav>
     <%= yield %>
   </body>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,6 +10,9 @@
   </head>
 
   <body>
+    <nav class='topnav'>
+      <%= link_to 'Login with GitHub', github_login_path unless current_user %>
+    </nav>
     <%= yield %>
   </body>
 </html>

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,0 +1,3 @@
+Rails.application.config.middleware.use OmniAuth::Builder do
+  provider :github, ENV['GITHUB_CLIENT_ID'], ENV['GITHUB_CLIENT_SECRET']
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,6 @@
 Rails.application.routes.draw do
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  get '/', to: 'home#index'
+
+  get '/auth/github', as: 'github_login'
+  get '/auth/github/callback', to: 'sessions#create'
 end

--- a/db/migrate/20200408223446_remove_columns_from_users.rb
+++ b/db/migrate/20200408223446_remove_columns_from_users.rb
@@ -1,0 +1,6 @@
+class RemoveColumnsFromUsers < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :users, :email, :string
+    remove_column :users, :password_digest, :string
+  end
+end

--- a/db/migrate/20200408225106_add_uid_to_users.rb
+++ b/db/migrate/20200408225106_add_uid_to_users.rb
@@ -1,0 +1,5 @@
+class AddUidToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :uid, :string
+  end
+end

--- a/db/migrate/20200408225710_add_default_role_to_users.rb
+++ b/db/migrate/20200408225710_add_default_role_to_users.rb
@@ -1,0 +1,5 @@
+class AddDefaultRoleToUsers < ActiveRecord::Migration[5.2]
+  def change
+    change_column_default :users, :role, 1
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_08_050542) do
+ActiveRecord::Schema.define(version: 2020_04_08_225710) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -43,12 +43,11 @@ ActiveRecord::Schema.define(version: 2020_04_08_050542) do
 
   create_table "users", force: :cascade do |t|
     t.string "name"
-    t.string "email"
-    t.string "password_digest"
-    t.integer "role"
+    t.integer "role", default: 1
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "group_id"
+    t.string "uid"
     t.index ["group_id"], name: "index_users_on_group_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,7 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+Group.destroy_all
+('1'..'4').to_a.each do |mod_number|
+  Group.create(name: "Mod #{mod_number}")
+end

--- a/spec/features/home/index_spec.rb
+++ b/spec/features/home/index_spec.rb
@@ -23,12 +23,12 @@ RSpec.describe 'Home Index -' do
         expect(page).to have_content('Welcome!')
         expect(page).to_not have_content('Logged in as ')
 
-        click_link 'Login with GitHub'
+        click_link 'Log in with GitHub'
 
         expect(current_path).to eq('/')
         expect(page).to have_content('Logged in as test-user')
         expect(page).to_not have_content('Logged in as other-user')
-        expect(page).to_not have_link('Login with GitHub')
+        expect(page).to_not have_link('Log in with GitHub')
       end
     end
 
@@ -37,11 +37,11 @@ RSpec.describe 'Home Index -' do
         User.create!(name: 'test-user', uid: '9999', group: @group)
         visit '/'
 
-        click_link 'Login with GitHub'
+        click_link 'Log in with GitHub'
 
         expect(current_path).to eq('/')
         expect(page).to have_content('Logged in as test-user')
-        expect(page).to_not have_link('Login with GitHub')
+        expect(page).to_not have_link('Log in with GitHub')
       end
     end
   end

--- a/spec/features/home/index_spec.rb
+++ b/spec/features/home/index_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+RSpec.describe 'Home Index -' do
+  describe 'Connecting with Github -' do
+    before(:each) do
+      @group = Group.create!(name: 'Test Group')
+      User.create!(name: 'other-user', uid: '1111', group: @group)
+
+      auth_mock = {
+        "provider"=>"github",
+        "uid"=> '9999',
+        "info"=> {"nickname"=>"test-user"}
+      }
+
+      OmniAuth.config.mock_auth[:github] = nil
+      OmniAuth.config.test_mode = true
+      OmniAuth.config.mock_auth[:github] = OmniAuth::AuthHash.new(auth_mock)
+    end
+
+    describe 'New User' do
+      it 'can create an account with github' do
+        visit '/'
+        expect(page).to have_content('Welcome!')
+        expect(page).to_not have_content('Logged in as ')
+
+        click_link 'Login with GitHub'
+
+        expect(current_path).to eq('/')
+        expect(page).to have_content('Logged in as test-user')
+        expect(page).to_not have_content('Logged in as other-user')
+        expect(page).to_not have_link('Login with GitHub')
+      end
+    end
+
+    describe 'Existing User' do
+      it 'can log in' do
+        User.create!(name: 'test-user', uid: '9999', group: @group)
+        visit '/'
+
+        click_link 'Login with GitHub'
+
+        expect(current_path).to eq('/')
+        expect(page).to have_content('Logged in as test-user')
+        expect(page).to_not have_link('Login with GitHub')
+      end
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2,14 +2,15 @@ require 'rails_helper'
 
 RSpec.describe User, type: :model do
   describe 'validations' do
-    it {should validate_presence_of(:name)}
-    it {should validate_presence_of(:email)}
-    it {should validate_presence_of(:password)}
-    it {should validate_presence_of(:role)}
+    it { should validate_presence_of(:name) }
+    it { should validate_presence_of(:role) }
+    it { should validate_presence_of(:uid) }
+    it { should validate_uniqueness_of(:uid) }
+    it { should define_enum_for(:role).with_values([:admin, :registered_user]) }
   end
 
   describe 'relationships' do
-    it {should have_many(:posts)}
-    it {should belong_to(:group)}
+    it { should have_many(:posts) }
+    it { should belong_to(:group) }
   end
 end


### PR DESCRIPTION
## Description
Add github authorization via `omniauth-github` gem

## Notes
Adds a login link which will prompt a user to log in with github
  - **to be changed:** for the time being, new users are created in the first group ('Mod 1')

Changes `User`'s `role` attribute into an enum
 - 0: admin, 1: registered user

A user's email and password are no longer stored in the database - instead, their github user id is stored as `uid`

Adds travis-ci integration

## RSpec Results
```
19 examples, 0 failures

Coverage report generated for RSpec - 97 / 97 LOC (100.0%) covered.
```
