### PR TITLE
DA/group joining

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,0 +1,5 @@
+class PostsController < ApplicationController
+  def index
+    @posts = Post.all
+  end
+end

--- a/app/controllers/profile/group_controller.rb
+++ b/app/controllers/profile/group_controller.rb
@@ -1,0 +1,5 @@
+class Profile::GroupController < ApplicationController
+  def new
+    @groups = Group.all
+  end
+end

--- a/app/controllers/profile/group_controller.rb
+++ b/app/controllers/profile/group_controller.rb
@@ -2,4 +2,19 @@ class Profile::GroupController < ApplicationController
   def new
     @groups = Group.all
   end
+
+  def create
+    group_id = group_params[:group_select]
+    group = Group.find_by(id: group_id)
+    if group
+      current_user.update(group_id: group_id)
+      flash[:sucess] = "You have joined #{group.name}!"
+    end
+    redirect_to posts_path
+  end
+
+  private
+    def group_params
+      params.permit(:group_select)
+    end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -6,7 +6,7 @@ class SessionsController < ApplicationController
 
     user = User.find_by(uid: [uid])
     if user.nil?
-      user = User.create(uid: uid, name: name, group_id: Group.first.id)
+      user = User.create(uid: uid, name: name)
     end
     session[:user_id] = user.id
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,11 +5,11 @@ class User < ApplicationRecord
 
   has_many :posts
 
-  belongs_to :group
+  belongs_to :group, optional: true
 
   enum role: { admin: 0, registered_user: 1 }
 
-  def post_count 
+  def post_count
     posts.count
   end
 end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -3,5 +3,5 @@
 <% if current_user && current_user.group.nil? %>
   <br>
   <p>It seems you haven't joined a group yet.</p>
-  <%= link_to 'Join a group now!', '/profile/group/edit' %>
+  <%= link_to 'Join a group now!', new_profile_group_path %>
 <% end %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,2 +1,7 @@
 <p><%= "Logged in as #{current_user.name}" if current_user %></p>
 <p>Welcome!</p>
+<% if current_user && current_user.group.nil? %>
+  <br>
+  <p>It seems you haven't joined a group yet.</p>
+  <%= link_to 'Join a group now!', '/profile/group/edit' %>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,7 +18,15 @@
       <% else %>
         <%= link_to 'Log in with GitHub', github_login_path  %>
       <% end %>
+
     </nav>
-    <%= yield %>
+    <% flash.each do |name, msg| %>
+      <div class= "<%=name%>-flash">
+        <p><%= msg %></p>
+      </div>
+    <% end %>
+    <center>
+      <%= yield %>
+    </center>
   </body>
 </html>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,0 +1,1 @@
+<h1>Post Index</h1>

--- a/app/views/profile/group/new.html.erb
+++ b/app/views/profile/group/new.html.erb
@@ -1,0 +1,4 @@
+<%= form_tag profile_group_index_path do %>
+  <%= select_tag :group_select, options_from_collection_for_select(@groups, "id", "name", "1") %>
+  <%= submit_tag 'Join' %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,5 +6,6 @@ Rails.application.routes.draw do
 
   namespace :profile do
     resources :stats, only: [:index]
+    resources :group, only: [:new, :create]
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,4 +8,6 @@ Rails.application.routes.draw do
     resources :stats, only: [:index]
     resources :group, only: [:new, :create]
   end
+
+  resources :posts, only: [:index]
 end

--- a/spec/factories/users_factory.rb
+++ b/spec/factories/users_factory.rb
@@ -3,6 +3,5 @@ FactoryBot.define do
     name { "#{Faker::Superhero.descriptor}-#{Faker::Name.first_name}" }
     role { 1 }
     uid { Faker::Number.number(digits: 10).to_s }
-    association :group
   end
 end

--- a/spec/features/profile/group/edit_spec.rb
+++ b/spec/features/profile/group/edit_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Profile/group edit page -' do
         visit '/'
 
         expect(page).to have_content("It seems you haven't joined a group yet.")
-        click_button('Join a group now!')
+        click_link('Join a group now!')
 
         expect(current_path).to eq('/profile/group/edit')
 

--- a/spec/features/profile/group/edit_spec.rb
+++ b/spec/features/profile/group/edit_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe 'Profile/group edit page -' do
+  describe 'Registered user' do
+    describe 'without a group' do
+      it 'can join a group' do
+        Group.create(name: 'Mod 1')
+        Group.create(name: 'Mod 2')
+        Group.create(name: 'Mod 3')
+        user = User.create(name: 'User', uid: '1111')
+        allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+        visit '/'
+
+        expect(page).to have_content("It seems you haven't joined a group yet.")
+        click_button('Join a group now!')
+
+        expect(current_path).to eq('/profile/group/edit')
+
+        select 'Mod 1', :from => 'groupSelect'
+        click_button('Join')
+
+        expect(current_path).to eq('/posts')
+        expect(page).to have_content('You have joined Mod 1!')
+        expect(page).to_not have_content("It seems you haven't joined a group yet.")
+      end
+    end
+  end
+end

--- a/spec/features/profile/group/new_spec.rb
+++ b/spec/features/profile/group/new_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe 'Profile/group edit page -' do
+RSpec.describe 'Profile/Group New -' do
   describe 'Registered user' do
     describe 'without a group' do
       it 'can join a group' do
@@ -15,7 +15,7 @@ RSpec.describe 'Profile/group edit page -' do
         expect(page).to have_content("It seems you haven't joined a group yet.")
         click_link('Join a group now!')
 
-        expect(current_path).to eq('/profile/group/edit')
+        expect(current_path).to eq(new_profile_group_path)
 
         select 'Mod 1', :from => 'groupSelect'
         click_button('Join')

--- a/spec/features/profile/group/new_spec.rb
+++ b/spec/features/profile/group/new_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'Profile/Group New -' do
 
         expect(current_path).to eq(new_profile_group_path)
 
-        select 'Mod 1', :from => 'groupSelect'
+        select 'Mod 1', :from => :group_select
         click_button('Join')
 
         expect(current_path).to eq('/posts')

--- a/spec/features/profile/group/new_spec.rb
+++ b/spec/features/profile/group/new_spec.rb
@@ -17,11 +17,11 @@ RSpec.describe 'Profile/Group New -' do
 
         expect(current_path).to eq(new_profile_group_path)
 
-        select 'Mod 1', :from => :group_select
+        select 'Mod 3', :from => :group_select
         click_button('Join')
 
         expect(current_path).to eq('/posts')
-        expect(page).to have_content('You have joined Mod 1!')
+        expect(page).to have_content('You have joined Mod 3!')
         expect(page).to_not have_content("It seems you haven't joined a group yet.")
       end
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe User, type: :model do
 
   describe 'relationships' do
     it { should have_many(:posts) }
-    it { should belong_to(:group) }
+    it { should belong_to(:group).optional(true) }
   end
 
   describe 'methods' do


### PR DESCRIPTION
## Description
Completes [User Story 2: Joining a Group](https://app.asana.com/0/1170154762648575/1170576892702729/f)

## Notes
Creating an account by logging in with GitHub no longer sets a default group

Users belonging to groups is now optional

Added a form that allows a user to pick their group

Added a placeholder `Posts Index` for the sake of redirecting

Removed group association from `users_factory` - factory generated users now default to being groupless

## RSpec Results
```
26 examples, 0 failures

Coverage report generated for RSpec - 238 / 238 LOC (100.0%) covered.
```
