### PR TITLE
DA/reactions buttons

### DIFF
--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,7 +1,13 @@
-<h2>Post <%= @post.id %></h2>
+<h2>Post</h2>
 
-<p>Group: <%= @post.user.group.name %></p>
-<p>Week #<%= @post.day.week %></p>
-<p>Day #<%= @post.day.day_of_week %></p>
-<p>Date: <%= @post.created_at.strftime("Posted on %m/%d/%Y at %I:%M%p") %></p>
+<p><%= @post.user.group.name %></p>
+<p class='.day-week'><%= "#{@post.day.day_of_week}," %> Week <%= @post.day.week %></p>
 <p><%= @post.body %></p>
+
+<section id='reactions'>
+  <%= button_to 'Like', '/' %>
+  <%= button_to 'Dislike', '/' %>
+  <%= button_to 'Can relate', '/' %>
+  <%= button_to 'Lol', '/' %>
+  <%= button_to 'Upset', '/' %>
+</section>

--- a/spec/features/posts/index_spec.rb
+++ b/spec/features/posts/index_spec.rb
@@ -1,33 +1,34 @@
 require 'rails_helper'
 
-RSpec.describe "As a Registered User in a group", type: :feature do
-  before(:each) do
-    @group_1 = Group.create(name: 'Mod 1')
-    @group_2 = Group.create(name: 'Mod 2')
-    @user = User.create(name: 'user', uid: '1111', group: @group_1)
-    @day_1 = Day.create(week: 1, day_of_week: 1, group: @group_1)
-    @day_2 = Day.create(week: 2, day_of_week: 5, group: @group_2)
-    @day_3 = Day.create(week: 4, day_of_week: 3, group: @group_1)
-    @day_4 = Day.create(week: 6, day_of_week: 4, group: @group_1)
-    @post_1 = Post.create(body: "Wow, first day of the mod 1... syllabus day... but still so lost @.@", tone: "confuse", day: @day_1, user: @user)
-    @post_2 = Post.create(body: "Just took my first in class challenge. I'm NEVER going to get any better at this!!", tone: "angry", day: @day_2, user: @user)
-    @post_3 = Post.create(body: "Learning that I gotta utilize my resources and getting better doesn't come out of thin air. Make sure to use paired.tech!!", tone: "optimistic", day: @day_3, user: @user)
-    @post_4 = Post.create(body: "Passed Mod 1!! Time to get schwifty with the Turing crew", tone: "excited", day: @day_4, user: @user)
-    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
-    visit '/'
-  end
+RSpec.describe 'Posts index -', type: :feature do
+  describe 'Registered user in a group' do
+    before(:each) do
+      @group_1 = Group.create(name: 'Mod 1')
+      @group_2 = Group.create(name: 'Mod 2')
+      @user = User.create(name: 'user', uid: '1111', group: @group_1)
+      @day_1 = Day.create(week: 1, day_of_week: 1, group: @group_1)
+      @day_2 = Day.create(week: 2, day_of_week: 5, group: @group_2)
+      @day_3 = Day.create(week: 4, day_of_week: 3, group: @group_1)
+      @day_4 = Day.create(week: 6, day_of_week: 4, group: @group_1)
+      @post_1 = Post.create(body: 'Wow, first day of the mod 1... syllabus day... but still so lost @.@', tone: 'confuse', day: @day_1, user: @user)
+      @post_2 = Post.create(body: "Just took my first in class challenge. I'm NEVER going to get any better at this!!", tone: 'angry', day: @day_2, user: @user)
+      @post_3 = Post.create(body: "Learning that I gotta utilize my resources and getting better doesn't come out of thin air. Make sure to use paired.tech!!", tone: 'optimistic', day: @day_3, user: @user)
+      @post_4 = Post.create(body: 'Passed Mod 1!! Time to get schwifty with the Turing crew', tone: 'excited', day: @day_4, user: @user)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
+      visit posts_path
+    end
 
-  it "when I visit the root path, I click on a link to the posts index page" do
-    click_link("See all posts!")
-    expect(current_path).to eq('/posts')
-  end
+    it 'sees a list of all posts belonging to that group' do
+      expect(page).to have_content("All Posts")
+      expect(page).to_not have_link("Click to see post #{@post_2.id}'s info.")
+      expect(page).to have_link("Click to see post #{@post_3.id}'s info.")
+      expect(page).to have_content(@post_3.body)
+    end
 
-  it "when on the posts index page, I see a list of all posts belonging to my group" do
-    click_link("See all posts!")
-    expect(page).to have_content("All Posts")
-    expect(page).to_not have_link("Click to see post #{@post_2.id}'s info.")
-    expect(page).to have_link("Click to see post #{@post_3.id}'s info.")
-    expect(page).to have_content(@post_3.body)
-  end
+    it "can click a link to see a post's show page" do
+      click_link("Click to see post #{@post_3.id}'s info.")
 
+      expect(current_path).to eq(post_path(@post_3))
+    end
+  end
 end

--- a/spec/features/posts/show_spec.rb
+++ b/spec/features/posts/show_spec.rb
@@ -1,39 +1,27 @@
 require 'rails_helper'
 
-RSpec.describe "Posts index - ", type: :feature do
+RSpec.describe 'Post show -', type: :feature do
   describe 'Registered user in a group' do
     before(:each) do
       @group_1 = Group.create(name: 'Mod 1')
-      @group_2 = Group.create(name: 'Mod 2')
-      @user = User.create(name: 'user', uid: '1111', group: @group_1)
-      @day_1 = Day.create(week: 1, day_of_week: 1, group: @group_1)
-      @day_2 = Day.create(week: 2, day_of_week: 5, group: @group_2)
-      @day_3 = Day.create(week: 4, day_of_week: 3, group: @group_1)
+      group_2 = Group.create(name: 'Mod 2')
+      user = User.create(name: 'user', uid: '1111', group: @group_1)
+      day_1 = Day.create(week: 1, day_of_week: 1, group: @group_1)
+      day_2 = Day.create(week: 2, day_of_week: 5, group: group_2)
+      day_3 = Day.create(week: 4, day_of_week: 3, group: @group_1)
       @day_4 = Day.create(week: 6, day_of_week: 4, group: @group_1)
-      @post_1 = Post.create(body: "Wow, first day of the mod 1... syllabus day... but still so lost @.@", tone: "confuse", day: @day_1, user: @user)
-      @post_2 = Post.create(body: "Just took my first in class challenge. I'm NEVER going to get any better at this!!", tone: "angry", day: @day_2, user: @user)
-      @post_3 = Post.create(body: "Learning that I gotta utilize my resources and getting better doesn't come out of thin air. Make sure to use paired.tech!!", tone: "optimistic", day: @day_3, user: @user)
-      @post_4 = Post.create(body: "Passed Mod 1!! Time to get schwifty with the Turing crew", tone: "excited", day: @day_4, user: @user)
-      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
-      visit '/posts'
+      Post.create(body: "Wow, first day of the mod 1... syllabus day... but still so lost @.@", tone: "confuse", day: day_1, user: user)
+      Post.create(body: "Just took my first in class challenge. I'm NEVER going to get any better at this!!", tone: "angry", day: day_2, user: user)
+      Post.create(body: "Learning that I gotta utilize my resources and getting better doesn't come out of thin air. Make sure to use paired.tech!!", tone: "optimistic", day: day_3, user: user)
+      @post_4 = Post.create(body: "Passed Mod 1!! Time to get schwifty with the Turing crew", tone: "excited", day: @day_4, user: user)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+      visit post_path(@post_4)
     end
 
-    it "can see a list of all posts belonging to that group" do
-      expect(page).to have_content("All Posts")
-      expect(page).to_not have_link("Click to see post #{@post_2.id}'s info.")
-      expect(page).to have_link("Click to see post #{@post_3.id}'s info.")
-      expect(page).to have_content(@post_3.body)
-    end
-
-    it "can click a link to see that post's information" do
-      click_link("Click to see post #{@post_4.id}'s info.")
-      expect(current_path).to eq(post_path(@post_4))
-
-      expect(page).to have_content(@post_4.id)
+    it "sees that post's information" do
       expect(page).to have_content(@group_1.name)
       expect(page).to have_content(@day_4.week)
       expect(page).to have_content(@day_4.day_of_week)
-      expect(page).to have_content(@post_4.created_at.strftime("Posted on %m/%d/%Y at %I:%M%p"))
       expect(page).to have_content(@post_4.body)
     end
   end

--- a/spec/features/posts/show_spec.rb
+++ b/spec/features/posts/show_spec.rb
@@ -24,5 +24,15 @@ RSpec.describe 'Post show -', type: :feature do
       expect(page).to have_content(@day_4.day_of_week)
       expect(page).to have_content(@post_4.body)
     end
+
+    it 'sees reaction buttons' do
+      within('#reactions') do
+        expect(page).to have_button('Like', count: 1)
+        expect(page).to have_button('Dislike', count: 1)
+        expect(page).to have_button('Can relate', count: 1)
+        expect(page).to have_button('Lol', count: 1)
+        expect(page).to have_button('Upset', count: 1)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Description
Completes [User Story 17: Post Show](https://app.asana.com/0/1170154762648575/1170778683506483/f)

## Notes
Small PR that adds buttons to a post's show page.

Refactors/reorganizes a few tests

All buttons currently link to the root path as a placeholder (real links added in next user stories)

## RSpec Results
```
39 examples, 0 failures

Coverage report generated for RSpec - 421 / 421 LOC (100.0%) covered.
```
