### PR TITLE
Da/pagination

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem 'figaro'
 gem 'addressable'
 gem 'materialize-sass'
 gem 'jquery-rails'
+gem 'will_paginate', '~> 3.1.0'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -242,6 +242,7 @@ GEM
     websocket-driver (0.7.1)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.4)
+    will_paginate (3.1.8)
     xpath (3.2.0)
       nokogiri (~> 1.8)
 
@@ -275,6 +276,7 @@ DEPENDENCIES
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
+  will_paginate (~> 3.1.0)
 
 RUBY VERSION
    ruby 2.5.1p57

--- a/app/controllers/admin/posts_controller.rb
+++ b/app/controllers/admin/posts_controller.rb
@@ -1,6 +1,6 @@
 class Admin::PostsController < Admin::BaseController
   def index
-    @posts = Post.all.order(created_at: :desc)
+    @posts = Post.all.order(created_at: :desc).paginate(page: params[:page], per_page: 10)
   end
 
   def destroy

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -30,8 +30,7 @@ class PostsController < ApplicationController
     end
 
     def get_tone
-      tone_service = ToneService.new
-      tone_service.get_tone_by_text(post_body)
+      ToneService.get_tone_by_text(post_body)
     end
 
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -9,4 +9,29 @@ class PostsController < ApplicationController
     @post = Post.find(params[:id])
   end
 
+  def create
+    post = Post.new(post_params)
+    if post.save
+      flash[:success] = 'You have made a post!'
+    else
+      flash[:errors] = post.errors.full_messages.to_sentence
+    end
+    redirect_to posts_path
+  end
+
+  private
+
+    def post_body
+      params.permit(:body)
+    end
+
+    def post_params
+      {day: day_today, tone: get_tone, user: current_user}.merge(post_body)
+    end
+
+    def get_tone
+      tone_service = ToneService.new
+      tone_service.get_tone_by_text(post_body)
+    end
+
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -2,7 +2,7 @@ class PostsController < ApplicationController
   before_action :require_user
 
   def index
-    @posts = day_today.posts
+    @posts = day_today.posts.paginate(page: params[:page], per_page: 1)
   end
 
   def show

--- a/app/controllers/profile/posts_controller.rb
+++ b/app/controllers/profile/posts_controller.rb
@@ -1,7 +1,7 @@
 class Profile::PostsController < Profile::BaseController
 
   def index
-    @posts = current_user.posts
+    @posts = current_user.posts.paginate(page: params[:page], per_page: 10)
   end
 
   def show

--- a/app/controllers/profile/posts_controller.rb
+++ b/app/controllers/profile/posts_controller.rb
@@ -8,28 +8,4 @@ class Profile::PostsController < Profile::BaseController
     @post = current_user.posts.find(params[:id])
   end
 
-  def create
-    post = Post.new(post_params)
-    if post.save
-      flash[:success] = 'You have made a post!'
-    else
-      flash[:errors] = post.errors.full_messages.to_sentence
-    end
-    redirect_to posts_path
-  end
-
-  private
-    def post_body
-      params.permit(:body)
-    end
-
-    def post_params
-      {day: day_today, tone: get_tone, user: current_user}.merge(post_body)
-    end
-
-    def get_tone
-      tone_service = ToneService.new
-      tone_service.get_tone_by_text(post_body)
-    end
-
 end

--- a/app/services/tone_service.rb
+++ b/app/services/tone_service.rb
@@ -1,6 +1,6 @@
 class ToneService
 
-  def get_tone_by_text(text)
+  def self.get_tone_by_text(text)
     response = conn.get("/api/v1/tone") do |request|
       request.params["body"] = text
       request.params["apikey"] = ENV["ANALYZER_API_KEY"]
@@ -10,7 +10,7 @@ class ToneService
 
   private
 
-  def conn
+  def self.conn
     Faraday.new(ENV["TONE_SERVICE_DOMAIN"])
   end
 

--- a/app/views/admin/posts/index.html.erb
+++ b/app/views/admin/posts/index.html.erb
@@ -1,6 +1,7 @@
 <h2>All Posts</h2>
 
 <% @posts.each do |post| %>
+  <p class ='small-font'><%= post.created_at.strftime("Posted on %m/%d/%Y at %I:%M%p") %></p>
   <%= render partial: "shared/ghosts", locals: {post: post, path: post_path(post.id), admin: true} %>
 <% end %>
 

--- a/app/views/admin/posts/index.html.erb
+++ b/app/views/admin/posts/index.html.erb
@@ -3,6 +3,7 @@
 <% @posts.each do |post| %>
   <p class ='small-font'><%= post.created_at.strftime("Posted on %m/%d/%Y at %I:%M%p") %></p>
   <%= render partial: "shared/ghosts", locals: {post: post, path: post_path(post.id), admin: true} %>
+  <br><br>
 <% end %>
 
 <%= will_paginate @posts, page_links: false, previous_label: '←', next_label: '→' %>

--- a/app/views/admin/posts/index.html.erb
+++ b/app/views/admin/posts/index.html.erb
@@ -3,3 +3,5 @@
 <% @posts.each do |post| %>
   <%= render partial: "shared/ghosts", locals: {post: post, path: post_path(post.id), admin: true} %>
 <% end %>
+
+<%= will_paginate @posts, page_links: false, previous_label: '←', next_label: '→' %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -2,6 +2,6 @@
 <% @posts.each do |post| %>
   <section class="post-<%= post.id %>">
   <%= render partial: "shared/ghosts", locals: { post: post, path: post_path(post.id), admin: false } %>
-  <%= will_paginate @posts %>
+  <%= will_paginate @posts, page_links: false, previous_label: '←', next_label: '→' %>
 
 <% end %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -2,4 +2,6 @@
 <% @posts.each do |post| %>
   <section class="post-<%= post.id %>">
   <%= render partial: "shared/ghosts", locals: { post: post, path: post_path(post.id), admin: false } %>
+  <%= will_paginate @posts %>
+
 <% end %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,5 +1,5 @@
-<h2><%= @post.day.group.name %></h2>
-<h4 class='day-week'><%= "#{@post.day.day_of_week}," %> Week <%= @post.day.week %></h4><br>
+<h4><%= @post.day.group.name %></h4>
+<h6 class='day-week'><%= "#{@post.day.day_of_week}," %> Week <%= @post.day.week %></h6>
 
 <%= render partial: "shared/ghosts", locals: { post: @post, path: post_path(@post.id), admin: false } %><br>
 <section id='reactions'>

--- a/app/views/profile/posts/index.html.erb
+++ b/app/views/profile/posts/index.html.erb
@@ -3,3 +3,5 @@
 <% @posts.each do |post| %>
   <%= render partial: "shared/ghosts", locals: { post: post, path: profile_post_path(post.id), admin: false } %>
 <% end %>
+
+<%= will_paginate @posts, page_links: false, previous_label: '←', next_label: '→' %>

--- a/app/views/profile/posts/show.html.erb
+++ b/app/views/profile/posts/show.html.erb
@@ -1,5 +1,5 @@
-<h2><%= @post.day.group.name %></h2>
-<h4 class='day-week'><%= "#{@post.day.day_of_week}," %> Week <%= @post.day.week %></h4>
+<h4><%= @post.day.group.name %></h4>
+<h6 class='day-week'><%= "#{@post.day.day_of_week}," %> Week <%= @post.day.week %></h6>
 
 <p class ='small-font'><%= @post.created_at.strftime("Posted on %m/%d/%Y at %I:%M%p") %></p>
 <%= render partial: "shared/ghosts", locals: { post: @post, path: profile_post_path(@post.id), admin: false } %>

--- a/app/views/shared/_new_post.html.erb
+++ b/app/views/shared/_new_post.html.erb
@@ -1,9 +1,9 @@
 <div class="container">
   <br>
-  <a class="btn-floating btn-large waves-effect waves-light modal-trigger red" href="#new-post"><i class="material-icons left prefix">create</i>New Post</a>
+  <a class="btn-floating btn-large waves-effect waves-light modal-trigger red accent-2" href="#new-post"><i class="material-icons left prefix">create</i>New Post</a>
   <div id="new-post" class="modal">
     <div class="modal-content">
-      <%= form_tag '/profile/posts', method: :post, class: 'col s12b' do %>
+      <%= form_tag posts_path, method: :post, class: 'col s12b' do %>
       <div class="input-field col s12">
         <i class="material-icons prefix">whatshot</i>
         <%= text_area_tag :body, nil, class:'materialize-textarea', :'data-length' => '222' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,10 +15,10 @@ Rails.application.routes.draw do
     get '/', to: 'dashboard#index'
     resources :stats, only: [:index]
     resources :group, only: [:new, :create]
-    resources :posts, only: [:index, :show, :create]
+    resources :posts, only: [:index, :show]
   end
 
-  resources :posts, only: [:index, :show] do
+  resources :posts, only: [:index, :show, :create] do
     resources :reactions, only: [:create, :destroy]
   end
 end

--- a/spec/features/posts/create_spec.rb
+++ b/spec/features/posts/create_spec.rb
@@ -4,24 +4,18 @@ RSpec.describe 'Posts create -', type: :feature do
   describe 'Registered user in a group' do
     before(:each) do
       group_1 = create(:group, name: 'Mod 1')
-      group_2 = create(:group, name: 'Mod 2')
       user = create(:user, group: group_1)
       @day_1 = create(:day, week: 1, day_of_week: 1, group: group_1)
-      day_2 = create(:day, week: 1, day_of_week: 1, group: group_2)
-      day_3 = create(:day, week: 1, day_of_week: 2, group: group_1)
-      create(:post, day: @day_1, user: user)
-      create(:post, day: @day_1, user: user)
-      create(:post, day: @day_1, user: user)
-      create(:post, day: day_2)
-      create(:post, day: day_3, user: user)
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
       allow_any_instance_of(ApplicationController).to receive(:day_today).and_return(@day_1)
+      allow_any_instance_of(PostsController).to receive(:get_tone).and_return("Test Tone")
 
       visit posts_path
     end
 
-    it 'can create a post with a generated tone, and add it to index list' do
-      expect(page).to have_css(".bubble", count: 3)
+    it 'can create a post' do
+      expect(page).to_not have_css(".bubble")
+
       fill_in :body, with: "This is my first post. What do you think?"
       click_on('Submit')
 
@@ -29,69 +23,30 @@ RSpec.describe 'Posts create -', type: :feature do
 
       @day_1.reload
       visit posts_path
-      post = Post.last
-      expect(page).to have_css(".bubble", count: 4)
+
+      expect(page).to have_css(".bubble", count: 1)
       expect(page).to have_content('This is my first post. What do you think?')
-      expect(post.tone).to eq('Analytical')
-    end
-
-    it 'can create a post with a generated tone if text has multiple sentences, and add it to index list' do
-      expect(page).to have_css(".bubble", count: 3)
-
-      text = "He’s more myself than I am. Whatever our souls are made of,
-      his and mine are the same…my great thought in living is himself."
-
-      fill_in :body, with: text
-      click_on('Submit')
-
-      expect(current_path).to eq(posts_path)
-
-      @day_1.reload
-      visit posts_path
-      post = Post.last
-
-      expect(page).to have_css(".bubble", count: 4)
-      expect(page).to have_css(".ghost-post-#{post.id}")
-      expect(post.tone).to eq('Joy')
-    end
-
-    it 'can create a post with no tone' do
-      expect(page).to have_css(".bubble", count: 3)
-      text = 'hmm'
-
-      fill_in :body, with: text
-      click_button('Submit')
-
-      expect(current_path).to eq(posts_path)
-
-      @day_1.reload
-      visit posts_path
-      post = Post.last
-
-      expect(page).to have_css(".bubble", count: 4)
-      expect(page).to have_css(".ghost-post-#{post.id}")
-      expect(post.tone).to eq('Default')
     end
 
     it 'can not create a post longer than 222 characters' do
-      expect(page).to have_css(".bubble", count: 3)
+      expect(page).to_not have_css(".bubble")
 
       text = "He’s more myself than I am. Whatever our souls are made of, his and mine are the same…my great thought in living is himself. If all else perished, and he remained, I should still continue to be; and if all else remained, and he were annihilated, the universe would turn to a mighty stranger. I should not seem a part of it."
 
       fill_in :body, with: text
       click_on('Submit')
 
-      expect(page).to have_css(".bubble", count: 3)
+      expect(page).to_not have_css(".bubble")
       expect(page).to have_content("Body is too long (maximum is 222 characters)")
     end
 
     it 'can not create an empty post' do
-      expect(page).to have_css(".bubble", count: 3)
+      expect(page).to_not have_css(".bubble")
 
       fill_in :body, with: ''
       click_on('Submit')
 
-      expect(page).to have_css(".bubble", count: 3)
+      expect(page).to_not have_css(".bubble")
       expect(page).to have_content("Body can't be blank")
     end
 

--- a/spec/features/posts/index_spec.rb
+++ b/spec/features/posts/index_spec.rb
@@ -20,13 +20,15 @@ RSpec.describe 'Posts index -', type: :feature do
       visit posts_path
     end
 
-    it 'sees a list of all posts belonging to that group' do
+    it 'sees a single posts belonging to that group' do
       expect(page).to_not have_css(".ghost-post-#{Post.fourth.id}")
       expect(page).to_not have_css(".ghost-post-#{Post.fifth.id}")
+
       expect(page).to have_css(".ghost-post-#{Post.first.id}")
-      expect(page).to have_css(".ghost-post-#{Post.second.id}")
-      expect(page).to have_css(".ghost-post-#{Post.third.id}")
       expect(page).to have_content(Post.first.body)
+
+      expect(page).to_not have_css(".ghost-post-#{Post.second.id}")
+      expect(page).to_not have_css(".ghost-post-#{Post.third.id}")
     end
 
     it "can click a link to see a post's show page" do


### PR DESCRIPTION
## Description
Paginates posts 

## Notes
Now only one post shows at a time on the `Posts Index`

Ten posts show at a time on `Profile Index` and `Admin Index`

Reroutes post creation - I think it makes more sense to post to `/posts` rather than `/profile/posts`

Update tests to reflect new changes

Stubs calls to tone analyzer, test suite should now be making 0 external calls - this brings the test coverage down a bit, service tests can be added to get back up to 100

## RSpec Results
```
74 examples, 0 failures

Coverage report generated for RSpec - 839 / 844 LOC (99.41%) covered.
```
