### PR TITLE
DA/week display

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -44,3 +44,7 @@ nav.nav-center ul li a {
 p.small-font {
   font-size: 8px;
 }
+
+.group-select {
+  width: 300px;
+}

--- a/app/assets/stylesheets/ghost.css
+++ b/app/assets/stylesheets/ghost.css
@@ -115,13 +115,13 @@ body {
 }
 
 #fear {
-  background: rebeccapurple;
+  background: #b388ff;
 }
 
 #joy {
-  background: yellow;
+  background: #ffe57f;
 }
 
 #anger {
-  background: red;
+  background: #ff5252;
 }

--- a/app/models/day.rb
+++ b/app/models/day.rb
@@ -4,4 +4,10 @@ class Day < ApplicationRecord
   belongs_to :group
   has_many :posts
   enum day_of_week: { Sunday: 0, Monday: 1, Tuesday: 2, Wednesday: 3, Thursday: 4, Friday: 5, Saturday: 6 }
+
+  def display_week
+    return 'Intermission Week' if week == 0
+    return 'Vacation Week' if week < 0
+    "Week #{week}"
+  end
 end

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,5 +1,5 @@
 <h4><%= @post.day.group.name %></h4>
-<h6 class='day-week'><%= "#{@post.day.day_of_week}," %> Week <%= @post.day.week %></h6>
+<h6 class='day-week'><%= "#{@post.day.day_of_week}," %><%= @post.day.display_week %></h6>
 
 <%= render partial: "shared/ghosts", locals: { post: @post, path: post_path(@post.id), admin: false } %><br>
 <section id='reactions'>

--- a/app/views/profile/group/new.html.erb
+++ b/app/views/profile/group/new.html.erb
@@ -1,5 +1,7 @@
 <p>Select a group to join</p>
-<%= form_tag profile_group_index_path do %>
-  <%= select_tag :group_select, options_from_collection_for_select(@groups, "id", "name", "1"), class: 'input-field' %>
-  <%= submit_tag 'Join', class:'waves-effect waves-light btn' %>
-<% end %>
+<div class="group-select">
+  <%= form_tag profile_group_index_path do %>
+    <%= select_tag :group_select, options_from_collection_for_select(@groups, "id", "name", "1"), class: 'input-field' %>
+    <%= submit_tag 'Join', class:'waves-effect waves-light btn cyan accent-3' %>
+  <% end %>
+</div>

--- a/app/views/profile/posts/show.html.erb
+++ b/app/views/profile/posts/show.html.erb
@@ -1,5 +1,5 @@
 <h4><%= @post.day.group.name %></h4>
-<h6 class='day-week'><%= "#{@post.day.day_of_week}," %> Week <%= @post.day.week %></h6>
+<h6 class='day-week'><%= "#{@post.day.day_of_week}," %><%= @post.day.display_week %></h6>
 
 <p class ='small-font'><%= @post.created_at.strftime("Posted on %m/%d/%Y at %I:%M%p") %></p>
 <%= render partial: "shared/ghosts", locals: { post: @post, path: profile_post_path(@post.id), admin: false } %>

--- a/spec/features/admin/posts/destroy_spec.rb
+++ b/spec/features/admin/posts/destroy_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Admin posts index -" do
     before(:each) do
       admin = create(:user, role: 0)
       day_1 = create(:day)
-      @post_1 = create(:post)
+      @post_1 = create(:post, body: "this is a unique post")
       create_list(:post, 4)
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
       allow_any_instance_of(ApplicationController).to receive(:day_today).and_return(day_1)

--- a/spec/models/day_spec.rb
+++ b/spec/models/day_spec.rb
@@ -11,4 +11,18 @@ RSpec.describe Day, type: :model do
     it { should belong_to(:group) }
     it { should have_many(:posts) }
   end
+
+  describe 'methods' do
+    it 'display_week' do
+      week_1 = create(:day, week: 1)
+      week_2 = create(:day, week: 2)
+      intermission = create(:day, week: 0)
+      vacation = create(:day, week: -1)
+
+      expect(week_1.display_week).to eq('Week 1')
+      expect(week_2.display_week).to eq('Week 2')
+      expect(intermission.display_week).to eq('Intermission Week')
+      expect(vacation.display_week).to eq('Vacation Week')
+    end
+  end
 end


### PR DESCRIPTION
## Description
Handles edge case weeks

## Notes
Assigns `-1` to a day's `week` when no week is found, and displays as "Vacation Week"
Assigns `0` to a day's `week` when "Intermission Week" is found, and displays as "Intermission Week"

Fixes style of select form for groups (narrows it)

Adjusts ghost colors


## RSpec Results
```
75 examples, 0 failures

Coverage report generated for RSpec - 860 / 865 LOC (99.42%) covered.
```
